### PR TITLE
feat: add register form and page ui

### DIFF
--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,0 +1,59 @@
+/**
+ * @file The main server-rendered page for the Register route.
+ *
+ * @architecture
+ * This is a Server Component. It handles metadata and the overall page layout,
+ * rendering the interactive `RegisterFeature` as a client-side island.
+ */
+import { Metadata } from "next";
+
+import { RegisterFeature } from "@/features/auth/components/register-feature";
+
+import { ThemeToggle } from "@/components/shared/theme-toggle";
+import { VisuallyHidden } from "@/components/shared/visually-hidden";
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
+
+export const metadata: Metadata = {
+  title: "Create Account",
+  description: "Sign up to get started",
+};
+
+export default function RegisterPage() {
+  return (
+    <main className="relative flex min-h-screen flex-col items-center justify-center p-4">
+      <div className="absolute top-4 right-4 z-10">
+        <ThemeToggle />
+      </div>
+
+      <VisuallyHidden>
+        <h1>Create an Account</h1>
+      </VisuallyHidden>
+
+      <div className="w-full max-w-xl">
+        <Card className="border-border/50 bg-background/80 hidden overflow-visible rounded-2xl border shadow-2xl shadow-black/10 backdrop-blur-lg sm:block dark:bg-black dark:shadow-black/50">
+          <CardHeader className="p-8 pb-4 text-center">
+            <h2 className="text-primary text-3xl font-bold tracking-tighter">Create an Account</h2>
+            <CardDescription className="pt-1">Enter your details below to sign up</CardDescription>
+          </CardHeader>
+          <CardContent className="p-8 pt-0">
+            <RegisterFeature />
+          </CardContent>
+        </Card>
+
+        <div className="block sm:hidden">
+          <div className="mb-6 text-center">
+            <h2 className="text-primary mb-2 text-3xl font-bold tracking-tighter">
+              Create an Account
+            </h2>
+            <p className="text-muted-foreground text-sm">Enter your details below to sign up</p>
+          </div>
+          <RegisterFeature />
+        </div>
+      </div>
+
+      <footer className="text-foreground-muted absolute bottom-4 px-4 text-center text-xs sm:bottom-4">
+        <p>&copy; {new Date().getFullYear()} This is an open-source boilerplate.</p>
+      </footer>
+    </main>
+  );
+}

--- a/src/features/auth/actions/register.action.ts
+++ b/src/features/auth/actions/register.action.ts
@@ -1,0 +1,40 @@
+/**
+ * @file Server Action for user registration.
+ *
+ * @architecture
+ * This action uses the `createApiAction` factory for consistent validation and state management.
+ * The handler is currently a mock that simulates a delay before succeeding.
+ * On success, it redirects the user to the main dashboard.
+ */
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { registerSchema } from "@/features/auth/schemas/register.schema";
+
+import { createApiAction } from "@/lib/safe-action";
+
+/**
+ * A mock handler that simulates a successful API call.
+ * In a real application, this would call the backend registration endpoint.
+ */
+const mockApiCall = () => {
+  return new Promise((resolve) => setTimeout(resolve, 1000));
+};
+
+export const registerAction = createApiAction({
+  name: "Register User",
+  schema: registerSchema,
+
+  // This handler is static for now, simulating a successful registration.
+  handler: async () => {
+    await mockApiCall();
+    // In a real app, you would return data from your API here.
+    return { success: true };
+  },
+
+  onSuccess: async () => {
+    // After a successful registration, send the user to the dashboard.
+    redirect("/dashboard");
+  },
+});

--- a/src/features/auth/components/login-form.tsx
+++ b/src/features/auth/components/login-form.tsx
@@ -11,6 +11,7 @@
 import Link from "next/link";
 
 import { RobotAvatar } from "@/features/auth/components/avatars/robot-avatar";
+import { SubmitButton } from "@/features/auth/components/submit-button";
 import type { UseLoginFormReturn } from "@/features/auth/hooks/use-login-form";
 
 import { PasswordInput } from "@/components/shared/password-input";
@@ -18,8 +19,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 import { cn } from "@/lib/utils";
-
-import { SubmitButton } from "./submit-button";
 
 /**
  * The presentational component for the login form.

--- a/src/features/auth/components/register-feature.tsx
+++ b/src/features/auth/components/register-feature.tsx
@@ -1,0 +1,19 @@
+/**
+ * @file Container component for the Register feature.
+ *
+ * @architecture
+ * This client component acts as the bridge between the `useRegisterForm` hook (logic)
+ * and the `RegisterForm` component (UI), ensuring a clean separation of concerns.
+ */
+"use client";
+
+import { RegisterForm } from "@/features/auth/components/register-form";
+import { useRegisterForm } from "@/features/auth/hooks/use-register-form";
+
+/**
+ * Renders the complete, interactive registration feature.
+ */
+export function RegisterFeature() {
+  const registerProps = useRegisterForm();
+  return <RegisterForm {...registerProps} />;
+}

--- a/src/features/auth/components/register-form.tsx
+++ b/src/features/auth/components/register-form.tsx
@@ -1,0 +1,118 @@
+/**
+ * @file This is the "Dumb" Presentational Component for the Register feature.
+ *
+ * @architecture
+ * It is completely stateless and receives all its data and event handlers as props from a "Smart Hook".
+ * Its sole responsibility is to render the UI based on the props it receives.
+ * This separation makes the component highly reusable, testable, and easy to reason about.
+ */
+"use client";
+
+import Link from "next/link";
+
+import { SubmitButton } from "@/features/auth/components/submit-button";
+import type { UseRegisterFormReturn } from "@/features/auth/hooks/use-register-form";
+
+import { PasswordInput } from "@/components/shared/password-input";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export function RegisterForm(props: UseRegisterFormReturn) {
+  const { state, action, isPending, handlePasswordVisibilityChange } = props;
+
+  return (
+    <div className="mx-auto w-full max-w-md">
+      <form action={action} className="grid grid-cols-1 gap-5">
+        <div className="grid gap-2">
+          <Label htmlFor="name" className={state.fieldErrors?.name ? "text-destructive" : ""}>
+            Full Name
+          </Label>
+          <Input
+            id="name"
+            name="name"
+            placeholder="John Doe"
+            autoComplete="name"
+            disabled={isPending}
+          />
+          {state.fieldErrors?.name && (
+            <p className="text-destructive text-xs">{state.fieldErrors.name[0]}</p>
+          )}
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor="email" className={state.fieldErrors?.email ? "text-destructive" : ""}>
+            Email
+          </Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="name@example.com"
+            autoComplete="email"
+            disabled={isPending}
+          />
+          {state.fieldErrors?.email && (
+            <p className="text-destructive text-xs">{state.fieldErrors.email[0]}</p>
+          )}
+        </div>
+
+        <div className="grid gap-2">
+          <Label
+            htmlFor="password"
+            className={state.fieldErrors?.password ? "text-destructive" : ""}
+          >
+            Password
+          </Label>
+          <PasswordInput
+            id="password"
+            name="password"
+            autoComplete="new-password"
+            disabled={isPending}
+            onVisibilityChange={handlePasswordVisibilityChange}
+          />
+          {state.fieldErrors?.password && (
+            <p className="text-destructive text-xs">{state.fieldErrors.password[0]}</p>
+          )}
+        </div>
+
+        <div className="grid gap-2">
+          <Label
+            htmlFor="confirmPassword"
+            className={state.fieldErrors?.confirmPassword ? "text-destructive" : ""}
+          >
+            Confirm Password
+          </Label>
+          <PasswordInput
+            id="confirmPassword"
+            name="confirmPassword"
+            autoComplete="new-password"
+            disabled={isPending}
+          />
+          {state.fieldErrors?.confirmPassword && (
+            <p className="text-destructive text-xs">{state.fieldErrors.confirmPassword[0]}</p>
+          )}
+        </div>
+
+        {!state.success && state.message && (
+          <div className="bg-destructive/15 text-destructive rounded-md p-3 text-sm font-medium">
+            {state.message}
+          </div>
+        )}
+
+        <div className="pt-2">
+          <SubmitButton buttonText="Sign up" pendingText="Signing up..." />
+        </div>
+      </form>
+
+      <div className="mt-6">
+        <Link
+          href="/login"
+          className="border-primary/20 text-link-muted hover:border-primary/40 hover:bg-primary/5 block w-full rounded-lg border-2 border-dashed p-3 text-center text-sm"
+        >
+          Already have an account?{" "}
+          <span className="text-primary-foreground-alt font-semibold">Sign in</span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/features/auth/components/submit-button.tsx
+++ b/src/features/auth/components/submit-button.tsx
@@ -1,22 +1,87 @@
+/**
+ * @file A form submission button that automatically handles pending states.
+ *
+ * @architecture
+ * **Why use `useFormStatus`?**
+ * This component leverages the `useFormStatus` hook from `react-dom`, which is a new
+ * feature in React 19. It provides the pending state of a parent `<form>` without
+ * any client-side state management (`useState`).
+ *
+ * **Benefits:**
+ * 1.  **Zero Client-Side JavaScript for State:** The pending state is managed by React itself,
+ *     contributing to a smaller client bundle and better performance.
+ * 2.  **Decoupling:** The button doesn't need to know anything about the server action or
+ *     the form's state. It's a truly "dumb," reusable component that just reacts to the
+ *     form's status.
+ * 3.  **Improved DX:** It automatically disables itself during submission to prevent
+ *     double-clicks, a common requirement for all forms.
+ */
 "use client";
 
+import * as React from "react";
+
+// <--- Import React
 import { Loader2 } from "lucide-react";
 import { useFormStatus } from "react-dom";
 
 import { Button } from "@/components/ui/button";
 
-export function SubmitButton() {
+// <--- Only import the Button component
+
+import { cn } from "@/lib/utils";
+
+/**
+ * The props for the SubmitButton component. It infers all props from the underlying
+ * Button component and adds its own custom props.
+ */
+interface SubmitButtonProps extends React.ComponentProps<typeof Button> {
+  // <--- THE FIX
+  /**
+   * The text to display when the form is not in a pending state.
+   * @default "Sign In"
+   */
+  buttonText?: string;
+  /**
+   * The text to display next to the spinner when the form is submitting.
+   * @default "Submitting..."
+   */
+  pendingText?: string;
+}
+
+/**
+ * ♿ **Form Submit Button**
+ *
+ * A specialized button for use inside forms that automatically shows a loading
+ * spinner and disables itself based on the form's submission status.
+ *
+ * @example
+ * // Inside a Server Component with a form
+ * <form action={myServerAction}>
+ *   <SubmitButton buttonText="Create User" pendingText="Creating..." />
+ * </form>
+ */
+export function SubmitButton({
+  buttonText = "Sign in",
+  pendingText = " Signing in...",
+  className,
+  ...props
+}: SubmitButtonProps) {
   const { pending } = useFormStatus();
 
   return (
-    <Button type="submit" className="w-full font-semibold" disabled={pending}>
+    <Button
+      type="submit"
+      className={cn("w-full font-semibold", className)}
+      disabled={pending}
+      {...props}
+    >
       {pending ? (
         <>
           <Loader2 className="mr-2 size-4 animate-spin" />
-          Signing in...
+          {pendingText}
         </>
       ) : (
-        "Sign in"
+        buttonText
       )}
     </Button>
   );

--- a/src/features/auth/hooks/use-register-form.ts
+++ b/src/features/auth/hooks/use-register-form.ts
@@ -1,0 +1,48 @@
+/**
+ * @file This is the "Smart Hook" for the Register feature.
+ *
+ * @architecture
+ * It encapsulates all state management, server action interactions, and event handling logic,
+ * exposing a clean, simplified API to the "Dumb" presentational component (`RegisterForm`).
+ */
+"use client";
+
+import { useState } from "react";
+
+import { registerAction } from "@/features/auth/actions/register.action";
+
+import { useServerAction } from "@/hooks/use-server-action";
+
+import { type ActionState } from "@/lib/safe-action";
+
+/**
+ * The return type for the `useRegisterForm` hook, providing all necessary props
+ * for the `RegisterForm` component.
+ */
+export interface UseRegisterFormReturn {
+  state: ActionState<unknown>;
+  action: (formData: FormData) => void;
+  isPending: boolean;
+  isPasswordVisible: boolean;
+  handlePasswordVisibilityChange: (isVisible: boolean) => void;
+}
+
+/**
+ * Custom hook to manage the state and logic of the Registration Form.
+ */
+export function useRegisterForm(): UseRegisterFormReturn {
+  const [state, action, isPending] = useServerAction(registerAction);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+
+  const handlePasswordVisibilityChange = (isVisible: boolean) => {
+    setIsPasswordVisible(isVisible);
+  };
+
+  return {
+    state,
+    action,
+    isPending,
+    isPasswordVisible,
+    handlePasswordVisibilityChange,
+  };
+}

--- a/src/features/auth/schemas/register.schema.ts
+++ b/src/features/auth/schemas/register.schema.ts
@@ -1,0 +1,22 @@
+/**
+ * @file Zod schema for the Registration form.
+ *
+ * @architecture
+ * This schema is used for server-side validation within the Server Action.
+ * The `.refine()` method provides cross-field validation to ensure passwords match.
+ */
+import { z } from "zod";
+
+export const registerSchema = z
+  .object({
+    name: z.string().min(2, { message: "Name must be at least 2 characters" }),
+    email: z.string().email({ message: "Please enter a valid email" }),
+    password: z.string().min(8, { message: "Password must be at least 8 characters" }),
+    confirmPassword: z.string().min(1, { message: "Please confirm your password" }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type RegisterInput = z.infer<typeof registerSchema>;


### PR DESCRIPTION
## Description

This PR adds the UI and basic structure for the Sign In / Register pages.

### What’s included:
- Register page UI
- Form layout and basic field structure
- Schema
- Routing for auth pages

### What’s NOT included (will come in next PR):
- Test cases
- API mocking / integration tests

Refs #23
